### PR TITLE
Sets CI/CD for the Music Store

### DIFF
--- a/bin/add-team.sh
+++ b/bin/add-team.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+TEAM=$(yq r ${PARAMS_YAML} common.team)
+OKTA_API_KEY=$(yq r ${PARAMS_YAML} okta.api-key)
+OKTA_AUTH_SERVER_CN=$(yq r ${PARAMS_YAML} okta.auth-server-fqdn)
+
+SHARED_SERVICES_CLUSTER=$(yq r ${PARAMS_YAML} musicstore.tmc.shared-services-cluster)
+PLATFORM_WORKSPACE=$(yq r ${PARAMS_YAML} musicstore.tmc.platform-workspace)
+
+WORKLOAD_CLUSTER=$(yq r ${PARAMS_YAML} musicstore.tmc.workload-cluster)
+WORKLOAD_WORKSPACE=$(yq r ${PARAMS_YAML} musicstore.tmc.workload-workspace)
+
+function check_okta_group() {
+    local name="${1}"
+    local first="$(curl --silent --location --get "https://${OKTA_AUTH_SERVER_CN}/api/v1/groups" \
+      --header 'Accept: application/json' \
+      --header "Authorization: SSWS ${OKTA_API_KEY}" \
+      --data "q=${name}" | jq -r ".[0].profile.name")"
+    [[ ${first} == ${name}  ]]
+}
+
+function add_okta_group() {
+    local name="${1}"
+    local description="${2}"
+    local group="$(jq -n --arg name "${name}" \
+                         --arg description "${description}" \
+                         -f okta/group.json)"
+
+    curl --silent --location --request POST "https://${OKTA_AUTH_SERVER_CN}/api/v1/groups" \
+      --header 'Accept: application/json' \
+      --header 'Content-Type: application/json' \
+      --header "Authorization: SSWS ${OKTA_API_KEY}" \
+      --data-raw "${group}" > /dev/null
+}
+
+function check_workspace() {
+    local name="${1}"
+    tmc workspace get "${name}" 2>/dev/null
+ }
+
+function add_workspace() {
+    local name="${1}"
+    local description="${2}"
+
+    tmc workspace create --name "${name}" --description "${description}"
+}
+
+function check_namespace() {
+    local cluster="${1}"
+    local workspace="${2}"
+    local name="${3}"
+    tmc cluster namespace get --name "${name}" \
+        --workspace-name ${workspace} --cluster-name ${cluster} \
+        --management-cluster-name attached  --provisioner-name attached 2>/dev/null
+}
+
+function add_namespace() {
+    local cluster="${1}"
+    local workspace="${2}"
+    local name="${3}"
+    local description="${4}"
+
+    tmc cluster namespace create --name "${name}" --description "${description}" \
+        --workspace-name ${workspace} --cluster-name ${cluster} \
+        --management-cluster-name attached  --provisioner-name attached
+}
+
+OKTA_GROUP="${TEAM}-devs"
+if ! check_okta_group "${OKTA_GROUP}" ; then
+    add_okta_group "${OKTA_GROUP}" "Steeltoe music store development team"
+fi
+
+CONCOURSE_MAIN_TARGET=$(yq r ${PARAMS_YAML} common.concourseMainTarget)
+if [[ -z $(fly -t ${CONCOURSE_MAIN_TARGET} teams --json | jq -r --arg team ${TEAM} '.[] | select ( .name == $team ) .name') ]] ; then
+    fly -t ${CONCOURSE_MAIN_TARGET} set-team --team-name ${TEAM} --oidc-group ${TEAM}-devs --non-interactive
+fi
+
+if ! check_workspace ${WORKLOAD_WORKSPACE} ; then
+    add_workspace ${WORKLOAD_WORKSPACE} "Steeltoe music store"
+fi
+
+if ! check_namespace ${WORKLOAD_CLUSTER} ${WORKLOAD_WORKSPACE} ${TEAM} ; then
+    add_namespace ${WORKLOAD_CLUSTER} ${WORKLOAD_WORKSPACE} ${TEAM} "Steeltoe music store production"
+fi
+
+STAGING_NAMESPACE=${TEAM}-staging
+if ! check_namespace ${WORKLOAD_CLUSTER} ${WORKLOAD_WORKSPACE} ${STAGING_NAMESPACE} ; then
+    add_namespace ${WORKLOAD_CLUSTER} ${WORKLOAD_WORKSPACE} ${STAGING_NAMESPACE} "Steeltoe music store staging"
+fi
+
+SECRETS_NAMESPACE=concourse-${TEAM}
+if ! check_namespace ${SHARED_SERVICES_CLUSTER} ${STAGING_NAMESPACE} ; then
+    add_namespace ${SHARED_SERVICES_CLUSTER} ${PLATFORM_WORKSPACE} ${SECRETS_NAMESPACE} "Steeltoe music store concourse secret store"
+fi
+
+SHAREDSVC_CLUSTER_NAME=$(yq r ${PARAMS_YAML} clusters.shared-services-cluster)
+PREVIOUS_CONTEXT=$(kubectl config current-context)
+# Install secrets in Shared Services Cluster
+kubectl config use-context $SHAREDSVC_CLUSTER_NAME-admin@$SHAREDSVC_CLUSTER_NAME
+
+ytt -f concourse/team -f ${PARAMS_YAML} --ignore-unknown-comments | 
+    kapp deploy -n tanzu-kapp -a ${TEAM}-secrets -f - -y
+
+kubectl config use-context ${PREVIOUS_CONTEXT}

--- a/bin/add-team.sh
+++ b/bin/add-team.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TEAM=$(yq r ${PARAMS_YAML} common.team)
+TEAM=${1} # (yq r ${PARAMS_YAML} common.team)
 OKTA_API_KEY=$(yq r ${PARAMS_YAML} okta.api-key)
 OKTA_AUTH_SERVER_CN=$(yq r ${PARAMS_YAML} okta.auth-server-fqdn)
 
@@ -49,9 +49,8 @@ function check_namespace() {
     local cluster="${1}"
     local workspace="${2}"
     local name="${3}"
-    tmc cluster namespace get --name "${name}" \
-        --workspace-name ${workspace} --cluster-name ${cluster} \
-        --management-cluster-name attached  --provisioner-name attached 2>/dev/null
+    tmc cluster namespace get "${name}" --cluster-name ${cluster} \
+        --management-cluster-name attached  --provisioner-name attached 
 }
 
 function add_namespace() {
@@ -72,7 +71,7 @@ fi
 
 CONCOURSE_MAIN_TARGET=$(yq r ${PARAMS_YAML} common.concourseMainTarget)
 if [[ -z $(fly -t ${CONCOURSE_MAIN_TARGET} teams --json | jq -r --arg team ${TEAM} '.[] | select ( .name == $team ) .name') ]] ; then
-    fly -t ${CONCOURSE_MAIN_TARGET} set-team --team-name ${TEAM} --oidc-group ${TEAM}-devs --non-interactive
+    fly -t ${CONCOURSE_MAIN_TARGET} set-team --team-name ${TEAM} --oidc-group ${TEAM}-devs --oidc-group platform-team --non-interactive
 fi
 
 if ! check_workspace ${WORKLOAD_WORKSPACE} ; then
@@ -89,16 +88,29 @@ if ! check_namespace ${WORKLOAD_CLUSTER} ${WORKLOAD_WORKSPACE} ${STAGING_NAMESPA
 fi
 
 SECRETS_NAMESPACE=concourse-${TEAM}
-if ! check_namespace ${SHARED_SERVICES_CLUSTER} ${STAGING_NAMESPACE} ; then
+if ! check_namespace ${SHARED_SERVICES_CLUSTER} ${PLATFORM_WORKSPACE} ${SECRETS_NAMESPACE} ; then
     add_namespace ${SHARED_SERVICES_CLUSTER} ${PLATFORM_WORKSPACE} ${SECRETS_NAMESPACE} "Steeltoe music store concourse secret store"
 fi
+
+TBS_NAMESPACE=tbs-project-${TEAM}
+HARBOR_DOMAIN=$(yq r $PARAMS_YAML commonSecrets.harborDomain)
+REGISTRY_USER=$(yq r $PARAMS_YAML commonSecrets.harborUser)
+REGISTRY_PASSWORD=$(yq r $PARAMS_YAML commonSecrets.harborPassword)
+if ! check_namespace ${SHARED_SERVICES_CLUSTER} ${PLATFORM_WORKSPACE} ${TBS_NAMESPACE} ; then
+    add_namespace ${SHARED_SERVICES_CLUSTER} ${PLATFORM_WORKSPACE} ${TBS_NAMESPACE} "Steeltoe music store TBS build namespace"
+    kp secret create harbor-creds \
+      --registry $HARBOR_DOMAIN \
+      --registry-user $REGISTRY_USER \
+      --namespace $TBS_NAMESPACE
+fi
+
 
 SHAREDSVC_CLUSTER_NAME=$(yq r ${PARAMS_YAML} clusters.shared-services-cluster)
 PREVIOUS_CONTEXT=$(kubectl config current-context)
 # Install secrets in Shared Services Cluster
 kubectl config use-context $SHAREDSVC_CLUSTER_NAME-admin@$SHAREDSVC_CLUSTER_NAME
 
-ytt -f concourse/team -f ${PARAMS_YAML} --ignore-unknown-comments | 
-    kapp deploy -n tanzu-kapp -a ${TEAM}-secrets -f - -y
+ytt -f concourse/team -f ${PARAMS_YAML} -v common.team=${TEAM} --ignore-unknown-comments | 
+    kapp deploy -n tanzu-kapp -a concourse-team-${TEAM} -f - -y
 
 kubectl config use-context ${PREVIOUS_CONTEXT}

--- a/bin/generate-and-apply-secrets.sh
+++ b/bin/generate-and-apply-secrets.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+TEAM=$(yq r ${PARAMS_YAML} common.team)
+ytt -f concourse/secrets -f secrets/lab.yml --ignore-unknown-comments | 
+    kapp deploy -n tanzu-kapp -a ${TEAM}-secrets -f - -y
+

--- a/bin/set-pipeline.sh
+++ b/bin/set-pipeline.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+fly -t $(yq r $PARAMS_YAML common.team) set-pipeline --pipeline musicstore --config concourse/pipeline/musicstore/pipeline.yml -n
+

--- a/concourse/pipeline/musicstore/pipeline.yml
+++ b/concourse/pipeline/musicstore/pipeline.yml
@@ -1,0 +1,655 @@
+resources:
+- name: source-code
+  type: git
+  source:
+    uri: ((musicstore.codeRepo))
+    paths:
+    - "src/**"
+- name: config-repo
+  type: git
+  source:
+    uri: ((musicstore.codeRepo))
+    paths:
+     - "k8s/**"
+- name: service-image
+  type: registry-image
+  source:
+    repository: ((musicstore.service-image))
+    tag: latest
+- name: ui-image
+  type: registry-image
+  source:
+    repository: ((musicstore.ui-image))
+    tag: latest
+- name: order-image
+  type: registry-image
+  source:
+    repository: ((musicstore.order-image))
+    tag: latest
+- name: cart-image
+  type: registry-image
+  source:
+    repository: ((musicstore.cart-image))
+    tag: latest
+- name: version
+  type: semver
+  source:
+    driver: git
+    uri: ((musicstore.codeRepo))
+    branch: version
+    file: version
+    username: ((common.githubUser))
+    password: ((common.githubToken))
+# - name: results
+#   type: s3
+#   source:
+#     bucket: ((sonarqube.resultsBucket))
+#     region_name: ((common.awsRegion))
+#     access_key_id: ((common.awsAccessKeyId))
+#     secret_access_key: ((common.awsSecretAccessKey))
+#     versioned_file: zap/musicstore.md
+
+jobs:
+- name: build
+  plan:
+  - get: source-code
+    trigger: true
+  - get: version
+    params:
+      pre: SNAPSHOT
+  - task: compile-and-test
+    output_mapping:
+      target: target
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: mcr.microsoft.com/dotnet/sdk
+          tag: 3.1
+      inputs:
+        - name: source-code
+      outputs:
+        - name: target
+      caches:
+        - path: source-code/maven
+      run:
+        path: /bin/bash
+        args:
+          - -c
+          - |
+            cd source-code
+            # Added -DskipTests and -Dcheckstyle.skip to speed up task for demo purpose
+            # They should not be included in a proper test pipeline
+            dotnet build MusicStore.sln 
+
+- name: test
+  plan:
+  - get: source-code
+    trigger: true
+    passed:
+    - build
+  - get: version
+    params:
+      pre: SNAPSHOT
+  - task: compile-and-test
+    output_mapping:
+      target: target
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: mcr.microsoft.com/dotnet/sdk
+          tag: 3.1
+      inputs:
+        - name: source-code
+      outputs:
+        - name: target
+      caches:
+        - path: source-code/maven
+      run:
+        path: /bin/bash
+        args:
+          - -c
+          - |
+            cd source-code
+            dotnet build MusicStore.sln
+
+- name: static-code-scan
+  plan:
+  - get: source-code
+    trigger: true
+    passed: 
+    - build
+  - task: sonarqube-scan
+    params:
+      # CA_CERT: ((ca_cert))
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: mcr.microsoft.com/dotnet/sdk
+          tag: 3.1
+      inputs:
+        - name: source-code
+      run:
+        path: bash
+        args:
+        - '-c'
+        - | 
+          cd source-code 
+          # dotnet sconarscanner start -d:sonar.host.url=https://((sonarqube.host))
+          dotnet build MusicStore.sln
+          # dotnet sonarscanner end -d:sonar.login=((sonarqube.token))
+
+- name: policy-validation
+  plan:
+  - get: source-code
+    trigger: true
+    passed: 
+    - static-code-scan
+    - test
+  - get: config-repo
+    trigger: true
+  - task: validate-k8s-objects
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: ((common.harborDomain))/tools/tanzu-application-toolkit
+      inputs:
+      - name: config-repo
+      run:
+        path: /bin/bash
+        args:
+        - -c
+        - |
+          conftest test --update oci://((common.harborDomain))/policy/workload-validation config-repo/k8s
+   
+- name: publish-store-image
+  plan: 
+    - get: source-code
+      passed: 
+      - static-code-scan
+      - test
+      trigger: true
+    - task: update-image
+      params:
+        KUBECONFIG_JSON: ((common.kubeconfigBuildServer))
+      input_mapping:
+        target: target
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((common.concourseHelperImage))
+        inputs:
+          - name: source-code
+        run:
+          path: /bin/bash
+          args:
+            - -c
+            - |
+              docker login ((common.harborDomain)) -u '((common.harborUser))' -p '((common.harborPassword))'
+              umask 077
+              echo $KUBECONFIG_JSON>kubeconfig.json
+              export KUBECONFIG=kubeconfig.json
+              set +e
+              kp image list -n ((musicstore.tbsNamespace)) | grep "steeltoe-musicstore-service" 
+              exists=$?
+              set -e
+              if [ $exists -eq 0 ]; then
+                kp image patch steeltoe-musicstore-service \
+                  --namespace ((musicstore.tbsNamespace)) \
+                  --wait \
+                  --local-path source-code/src/MusicStoreService
+              else
+                kp image create steeltoe-musicstore-service \
+                  --tag ((musicstore.service-image)) \
+                  --cluster-builder default \
+                  --namespace ((musicstore.tbsNamespace)) \
+                  --wait \
+                  --local-path source-code/src/MusicStoreService
+              fi
+    - get: service-image
+
+- name: publish-ui-image
+  plan: 
+    - get: source-code
+      passed: 
+      - static-code-scan
+      - test
+      trigger: true
+    - task: update-image
+      params:
+        KUBECONFIG_JSON: ((common.kubeconfigBuildServer))
+      input_mapping:
+        target: target
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((common.concourseHelperImage))
+        inputs:
+          - name: source-code
+        run:
+          path: /bin/bash
+          args:
+            - -c
+            - |
+              docker login ((common.harborDomain)) -u '((common.harborUser))' -p '((common.harborPassword))'
+              umask 077
+              echo $KUBECONFIG_JSON>kubeconfig.json
+              export KUBECONFIG=kubeconfig.json
+              set +e
+              kp image list -n ((musicstore.tbsNamespace)) | grep "steeltoe-musicstore-ui" 
+              exists=$?
+              set -e
+              if [ $exists -eq 0 ]; then
+                kp image patch steeltoe-musicstore-ui \
+                  --namespace ((musicstore.tbsNamespace)) \
+                  --wait \
+                  --local-path source-code/src/MusicStoreUI
+              else
+                kp image create steeltoe-musicstore-ui \
+                  --tag ((musicstore.ui-image)) \
+                  --cluster-builder default \
+                  --namespace ((musicstore.tbsNamespace)) \
+                  --wait \
+                  --local-path source-code/src/MusicStoreUI
+              fi
+    - get: ui-image
+
+- name: publish-order-image
+  plan: 
+    - get: source-code
+      passed: 
+      - static-code-scan
+      - test
+      trigger: true
+    - task: update-image
+      params:
+        KUBECONFIG_JSON: ((common.kubeconfigBuildServer))
+      input_mapping:
+        target: target
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((common.concourseHelperImage))
+        inputs:
+          - name: source-code
+        run:
+          path: /bin/bash
+          args:
+            - -c
+            - |
+              docker login ((common.harborDomain)) -u '((common.harborUser))' -p '((common.harborPassword))'
+              umask 077
+              echo $KUBECONFIG_JSON>kubeconfig.json
+              export KUBECONFIG=kubeconfig.json
+              set +e
+              kp image list -n ((musicstore.tbsNamespace)) | grep "steeltoe-musicstore-order-service" 
+              exists=$?
+              set -e
+              if [ $exists -eq 0 ]; then
+                kp image patch steeltoe-musicstore-order-service \
+                  --namespace ((musicstore.tbsNamespace)) \
+                  --wait \
+                  --local-path source-code/src/OrderService
+              else
+                kp image create steeltoe-musicstore-order-service \
+                  --tag ((musicstore.order-image)) \
+                  --cluster-builder default \
+                  --namespace ((musicstore.tbsNamespace)) \
+                  --wait \
+                  --local-path source-code/src/OrderService
+              fi
+    - get: order-image
+
+- name: publish-cart-image
+  plan: 
+    - get: source-code
+      passed: 
+      - static-code-scan
+      - test
+      trigger: true
+    - task: update-image
+      params:
+        KUBECONFIG_JSON: ((common.kubeconfigBuildServer))
+      input_mapping:
+        target: target
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((common.concourseHelperImage))
+        inputs:
+          - name: source-code
+        run:
+          path: /bin/bash
+          args:
+            - -c
+            - |
+              docker login ((common.harborDomain)) -u '((common.harborUser))' -p '((common.harborPassword))'
+              umask 077
+              echo $KUBECONFIG_JSON>kubeconfig.json
+              export KUBECONFIG=kubeconfig.json
+              set +e
+              kp image list -n ((musicstore.tbsNamespace)) | grep "steeltoe-musicstore-cart-service" 
+              exists=$?
+              set -e
+              if [ $exists -eq 0 ]; then
+                kp image patch steeltoe-musicstore-cart-service \
+                  --namespace ((musicstore.tbsNamespace)) \
+                  --wait \
+                  --local-path source-code/src/ShoppingCartService
+              else
+                kp image create steeltoe-musicstore-cart-service \
+                  --tag ((musicstore.cart-image)) \
+                  --cluster-builder default \
+                  --namespace ((musicstore.tbsNamespace)) \
+                  --wait \
+                  --local-path source-code/src/ShoppingCartService
+              fi
+    - get: cart-image
+
+# - name: application-scan
+#   public: true
+#   serial: true
+#   plan:
+#     - get: steeltoe-musicstore-image
+#       trigger: true
+#     - get: config-repo
+#       passed: 
+#       - policy-validation
+#       trigger: true
+#     - get: source-code
+#       passed: 
+#       - publish-store-image
+#       - publish-ui-image
+#       - publish-order-image
+#       - publish-cart-image
+#       trigger: true
+#     - task: deploy-db
+#       params:
+#         KUBECONFIG_JSON: ((common.kubeconfigAppServer))
+#       config:
+#         platform: linux
+#         image_resource:
+#           type: docker-image
+#           source:
+#             repository: ((common.concourseHelperImage))
+#             tag: latest
+#         inputs:
+#           - name: config-repo
+#           - name: steeltoe-musicstore-image
+#         run:
+#           path: /bin/bash
+#           args:
+#             - -c
+#             - |
+#               export DIGEST=$(cat steeltoe-musicstore-image/digest)
+
+#               # TODO Need to setup the kubeconfig
+#               umask 077
+#               echo $KUBECONFIG_JSON>kubeconfig.json
+#               export KUBECONFIG=kubeconfig.json
+
+#               cat > values.yaml <<VALUES
+#               auth:
+#                 rootPassword: musicstore
+#                 database: musicstore
+#                 username: musicstore
+#                 password: musicstore
+#               image:
+#                 registry: ((common.harborDomain))
+#                 repository: catalog/mysql
+#                 tag: latest
+#               secondary:
+#                 replicaCount: 0
+#               VALUES
+              
+#               helm repo add tac https://charts.trials.tac.bitnami.com/demo
+#               helm upgrade --install musicstore-db tac/mysql -n musicstore-staging -f values.yaml --wait
+
+#     - task: deploy-app
+#       params:
+#         KUBECONFIG_JSON: ((common.kubeconfigAppServer))
+#       config:
+#         platform: linux
+#         image_resource: 
+#           type: docker-image
+#           source :
+#             repository: ((common.concourseHelperImage))
+#             tag: latest
+#         inputs:
+#           - name: config-repo
+#           - name: steeltoe-musicstore-image
+#         run:
+#           path: /bin/bash
+#           args:
+#             - -c
+#             - |
+#               export DIGEST=$(cat steeltoe-musicstore-image/digest)
+
+#               # TODO Need to setup the kubeconfig
+#               umask 077
+#               echo $KUBECONFIG_JSON>kubeconfig.json
+#               export KUBECONFIG=kubeconfig.json
+
+#               cat > config-repo/k8s/values.yml <<VALUES
+#               #@data/values
+#               ---
+#               musicstore:
+#                 host: ((musicstore.stagingPrefix))-${DIGEST:7:17}.((musicstore.stagingDomain))
+#                 image: ((musicstore.image))@$DIGEST
+#                 wavefront:
+#                   applicationName: ((musicstore.wavefrontApplicationName))-staging
+#                   uri: ((musicstore.wavefrontUri))
+#                   apiToken: ((musicstore.wavefrontApiToken))
+#               VALUES
+              
+#               cat > config-repo/k8s/issuer.yaml <<OVERLAY
+#               #@ load("@ytt:overlay", "overlay")
+#               #@overlay/match by=overlay.subset({"kind":"Ingress"}),expects="1+"
+#               ---
+#               metadata:
+#                 annotations: 
+#                   cert-manager.io/cluster-issuer: letsencrypt-staging-contour-cluster-issuer
+#               OVERLAY
+#               ytt -f config-repo/k8s --ignore-unknown-comments | kapp deploy -n musicstore-staging --into-ns musicstore-staging -a musicstore -y -f -
+
+#     - task: prepare-results-path
+#       config:
+#         platform: linux
+#         image_resource: 
+#           type: docker-image
+#           source :
+#             repository: ((common.concourseHelperImage))
+#             tag: latest
+#         outputs:
+#           - name: results
+#         run:
+#           path: /bin/bash
+#           args:
+#             - '-c' 
+#             - |
+#               output_dir=$(pwd)/results/zap
+#               mkdir ${output_dir} && chgrp 1000 ${output_dir} && chmod g+w ${output_dir}
+
+#     - task: quick-scan
+#       params:
+#         # CA_CERT: ((ca_cert))
+#       config:
+#         platform: linux
+#         image_resource:
+#           type: registry-image
+#           source:
+#             repository: ((common.harborDomain))/tools/zap2docker-weekly
+#             tag: latest
+#         inputs:
+#         - name: steeltoe-musicstore-image
+#         - name: results
+#         outputs:
+#         - name: results
+#         run:
+#           path: bash
+#           args:
+#           - '-c'
+#           - | 
+#             export DIGEST=$(cat steeltoe-musicstore-image/digest)
+#             export TARGET=https://((musicstore.stagingPrefix))-${DIGEST:7:17}.((musicstore.stagingDomain))
+
+#             zap-cli start --start-options '-config api.disablekey=true' 
+#             zap-cli -v quick-scan --spider --ajax-spider --scanners all "${TARGET}" 
+#             zap-cli report -f md -o results/zap/musicstore.md
+#             zap-cli shutdown
+
+#     - put: results      
+#       params:
+#         file: results/zap/musicstore.md
+
+
+#     - task: cleanup
+#       params:
+#         KUBECONFIG_JSON: ((common.kubeconfigAppServer))
+#       config:
+#         platform: linux
+#         image_resource:
+#           type: docker-image
+#           source:
+#             repository: ((common.concourseHelperImage))
+#             tag: latest
+#         inputs:
+#           - name: config-repo
+#           - name: steeltoe-musicstore-image
+#         run:
+#           path: /bin/bash
+#           args:
+#             - -c
+#             - |
+#               export DIGEST=$(cat steeltoe-musicstore-image/digest)
+
+#               # TODO Need to setup the kubeconfig
+#               umask 077
+#               echo $KUBECONFIG_JSON>kubeconfig.json
+#               export KUBECONFIG=kubeconfig.json
+              
+#               kapp delete -n musicstore-staging -a musicstore --filter '{ "not": { "resource" : { "kinds": [ "AntreaControllerInfo" ] } } }' -y
+#               helm delete -n musicstore-staging musicstore-db 
+
+ 
+- name: production-deployment
+  public: true
+  serial: true
+  plan:
+    - get: service-image
+      trigger: true
+      passed:
+      - publish-store-image
+    - get: ui-image
+      trigger: true
+      passed:
+      - publish-ui-image
+    - get: order-image
+      trigger: true
+      passed:
+      - publish-order-image
+    - get: cart-image
+      trigger: true
+      passed:
+      - publish-cart-image
+    - get: config-repo
+      passed: 
+      - policy-validation
+      trigger: true
+    - task: create-wavefront-event
+      params:
+        WAVEFRONT_API_TOKEN: ((musicstore.wavefrontApiToken))
+        WAVEFRONT_URL: ((musicstore.wavefrontUri))
+        WAVEFRONT_DEPLOY_EVENT_NAME: ((musicstore.wavefrontDeployEventName))
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((common.concourseHelperImage))
+            tag: latest
+        run:
+          path: /bin/bash
+          args:
+            - -c
+            - |
+              set -euo pipefail
+
+              START_TIME=$(date +%s000)
+              sleep 1
+              END_TIME=$(date +%s000)
+
+              curl \
+                -X POST \
+                --header "Content-Type: application/json" \
+                --header "Accept: application/json" \
+                --header "Authorization: Bearer ${WAVEFRONT_API_TOKEN}" \
+                -d "{
+                  \"name\": \"${WAVEFRONT_DEPLOY_EVENT_NAME}\",
+                  \"annotations\": {
+                    \"severity\": \"info\",
+                    \"type\": \"image deploy\",
+                    \"details\": \"new steeltoe-musicstore image deployed\"
+                  },
+                  \"startTime\": "${START_TIME}",
+                  \"endTime\": "${END_TIME}"
+                }" "${WAVEFRONT_URL}/api/v2/event"
+
+    - task: deploy-app
+      params:
+        KUBECONFIG_JSON: ((common.kubeconfigAppServer))
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: ((common.concourseHelperImage))
+            tag: latest
+        inputs:
+          - name: config-repo
+        run:
+          path: /bin/bash
+          args:
+            - -c
+            - |
+
+              # TODO Need to setup the kubeconfig
+              umask 077
+              echo $KUBECONFIG_JSON>kubeconfig.json
+              export KUBECONFIG=kubeconfig.json
+
+              cat > config-repo/k8s/values.yml <<VALUES
+              #@data/values
+              ---
+              musicstore:
+                host: ((musicstore.host))
+                wavefront:
+                  applicationName: ((musicstore.wavefrontApplicationName))
+                  uri: ((musicstore.wavefrontUri))
+                  apiToken: ((musicstore.wavefrontApiToken))
+              registry:
+                host: ((common.harborDomain))
+                project: ((musicstore.project))
+              VALUES
+              cat config-repo/k8s/values.yml
+              
+              ytt -f config-repo/k8s --ignore-unknown-comments | kapp deploy -n musicstore -a musicstore -y -f -
+
+    - put: version
+      params:
+        pre: SNAPSHOT

--- a/concourse/secrets/common.yaml
+++ b/concourse/secrets/common.yaml
@@ -1,0 +1,23 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:base64", "base64")
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: common
+  namespace: #@ "concourse-{}".format(data.values.common.team)
+type: Opaque
+data:
+  harborDomain: #@ base64.encode(data.values.common.harborDomain)
+  harborUser: #@ base64.encode(data.values.common.harborUser)
+  harborPassword: #@ base64.encode(data.values.common.harborPassword)
+  kubeconfigBuildServer: #@ base64.encode(data.values.common.kubeconfigBuildServer)
+  kubeconfigAppServer: #@ base64.encode(data.values.common.kubeconfigAppServer)
+  concourseHelperImage: #@ base64.encode(data.values.common.concourseHelperImage)
+  githubUser: #@ base64.encode(data.values.common.githubUser)
+  githubToken: #@ base64.encode(data.values.common.githubToken)
+  awsAccessKeyId: #@ base64.encode(data.values.common.awsAccessKeyId)
+  awsSecretAccessKey: #@ base64.encode(data.values.common.awsSecretAccessKey)
+  awsRegion: #@ base64.encode(data.values.common.awsRegion)
+  
+  

--- a/concourse/secrets/petclinic.yaml
+++ b/concourse/secrets/petclinic.yaml
@@ -1,0 +1,25 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:base64", "base64")
+---  
+apiVersion: v1
+kind: Secret
+metadata:
+  name: musicstore
+  namespace: #@ "concourse-{}".format(data.values.common.team)
+type: Opaque
+data:
+  host: #@ base64.encode(data.values.musicstore.host)
+  project: #@ base64.encode(data.values.common.team)
+  stagingPrefix: #@ base64.encode(data.values.musicstore.stagingPrefix)
+  stagingDomain: #@ base64.encode(data.values.musicstore.stagingDomain)
+  service-image: #@ base64.encode(data.values.musicstore.serviceImage)
+  ui-image: #@ base64.encode(data.values.musicstore.uiImage)
+  order-image: #@ base64.encode(data.values.musicstore.orderImage)
+  cart-image: #@ base64.encode(data.values.musicstore.cartImage)
+  tbsNamespace: #@ base64.encode(data.values.musicstore.tbs.namespace)
+  wavefrontApplicationName: #@ base64.encode(data.values.musicstore.wavefront.applicationName)
+  wavefrontUri: #@ base64.encode(data.values.musicstore.wavefront.uri)
+  wavefrontApiToken: #@ base64.encode(data.values.musicstore.wavefront.apiToken)
+  wavefrontDeployEventName: #@ base64.encode(data.values.musicstore.wavefront.deployEventName)
+  configRepo: #@ base64.encode(data.values.musicstore.configRepo)
+  codeRepo: #@ base64.encode(data.values.musicstore.codeRepo)

--- a/concourse/secrets/sonarqube.yaml
+++ b/concourse/secrets/sonarqube.yaml
@@ -1,0 +1,14 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:base64", "base64")
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sonarqube
+  namespace: #@ "concourse-{}".format(data.values.common.team)
+type: Opaque
+data:
+  host: #@ base64.encode(data.values.sonarqube.host)
+  token: #@ base64.encode(data.values.sonarqube.token)
+  resultsBucket: #@ base64.encode(data.values.sonarqube.resultsBucket)
+  adminPassword: #@ base64.encode(data.values.sonarqube.adminPassword)
+  databasePassword: #@ base64.encode(data.values.sonarqube.databasePassword)

--- a/concourse/team/rolebinding.yml
+++ b/concourse/team/rolebinding.yml
@@ -1,0 +1,18 @@
+#@ load("@ytt:data", "data")
+
+#@ namespace   = "concourse-{}".format(data.values.common.team)
+#@ rolebinding = "concourse-web-{}".format(namespace)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: #@ rolebinding
+  namespace: #@ namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: concourse-web
+subjects:
+- kind: ServiceAccount
+  name: concourse-web
+  namespace: #@ data.values.common.concourseNamespace

--- a/okta/group.json
+++ b/okta/group.json
@@ -1,0 +1,6 @@
+{
+  "profile": {
+    "name": $name,
+    "description": $description
+  }
+}


### PR DESCRIPTION
TL;DR
-----

Adds a Concourse pipeline and scripts to simplify configuring it

Details
-------

Supports CI/CD for the Music Store demo application by adding a
Concourse pipeline and some scripts to simplify configuring it. The
pipeline executes build and test steps using .NET Core tools and 
then uses the Tanzu Build Service to create container images for 
each application/service that is part of the Music Store. It also uses 
`conftest` to validate the Kubernetes objects before deployment.

Has two scripts to facilitate setup:

1. `add-team.sh` which sets up Okta, Concourse, and Kubernetes
   for a new team workspace. The script creates and Okta group for
   the team, adds the required namespaces to the shared services 
   and workload clusters, and assure that the Okta group has the 
   right access to their namespaces.
2. `set-pipeline.sh` creates the Concourse pipeline. It's fairly
   straightforward right now but reduces the risk of typos.
   
The pipeline currently as a placeholder for static code scanning,
which is the next thing I'll be adding. It also has a commented 
out segment from its Java counterpart for doing an application 
scan that will come after that.