### PR TITLE
Automates Harbor configuration

### DIFF
--- a/bin/setup-harbor.sh
+++ b/bin/setup-harbor.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+REGISTRY=$(yq r $PARAMS_YAML common.harborDomain)
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/steeltoe.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/musicstore.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/sqlserver.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data @harbor/registry/mcr.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data @harbor/registry/hub.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/sqlserver.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/sqltools.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/eurekaserver.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/hystrix.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/configserver.json

--- a/harbor/replication/configserver.json
+++ b/harbor/replication/configserver.json
@@ -1,0 +1,31 @@
+{
+  "name": "configserver",
+  "description": "",
+  "creator": "admin",
+  "src_registry": {
+    "id": 4
+  },
+  "dest_registry": {
+    "id": 0
+  },
+  "dest_namespace": "steeltoe",
+  "filters": [
+      {
+          "type": "name",
+          "value": "steeltoeoss/config-server"
+      },
+      {
+          "type": "tag",
+          "value": "latest"
+      }
+  ],
+  "trigger": {
+    "type": "scheduled",
+    "trigger_settings": {
+      "cron": "0 20 10 */1,7,14,28 * *"
+    }
+  },
+  "deletion": false,
+  "override": true,
+  "enabled": true
+}

--- a/harbor/replication/sqltools.json
+++ b/harbor/replication/sqltools.json
@@ -1,0 +1,31 @@
+{
+  "name": "sqltools",
+  "description": "",
+  "creator": "admin",
+  "src_registry": {
+    "id": 6
+  },
+  "dest_registry": {
+    "id": 0
+  },
+  "dest_namespace": "mssql",
+  "filters": [
+      {
+          "type": "name",
+          "value": "mssql-tools"
+      },
+      {
+          "type": "tag",
+          "value": "latest"
+      }
+  ],
+  "trigger": {
+    "type": "scheduled",
+    "trigger_settings": {
+      "cron": "0 20 10 */1,7,14,28 * *"
+    }
+  },
+  "deletion": false,
+  "override": true,
+  "enabled": true
+}


### PR DESCRIPTION
TL;DR
-----

Scripts Harbor setup to make it easier and more repeatable

Details
-------

Adds a simple script that configure Harbor for the Lab. The script
sets up the projects, remote registries, and replications used by
the lab. Right now it doesn't check if the entities exist before
attempting to create them, so if you run it multiple times you'll
see 409 errors for the objects that have already been created.

Also includes two additiona replication configurations that are
needed for the Music Store infrastructure: the Spring Cloud Config
Server and Microsoft's SQL tools image which is useful for taking
a look at the SQL Server database if things are amiss.
