### PR TITLE
Adds static scan to the pipeline

### DIFF
--- a/bin/build-and-push-scanner-image.sh
+++ b/bin/build-and-push-scanner-image.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+REGISTRY=$(yq r $PARAMS_YAML common.harborDomain)
+docker build -t  dotnet-sonarscanner docker/dotnet-sonarscanner
+docker tag dotnet-sonarscanner:latest ${REGISTRY}/tools/dotnet-sonarscanner:latest
+docker push ${REGISTRY}/tools/dotnet-sonarscanner:latest

--- a/concourse/pipeline/musicstore/pipeline.yml
+++ b/concourse/pipeline/musicstore/pipeline.yml
@@ -130,8 +130,7 @@ jobs:
       image_resource:
         type: docker-image
         source:
-          repository: mcr.microsoft.com/dotnet/sdk
-          tag: 3.1
+          repository: ((common.harborDomain))/tools/dotnet-sonarscanner
       inputs:
         - name: source-code
       run:
@@ -140,9 +139,9 @@ jobs:
         - '-c'
         - | 
           cd source-code 
-          # dotnet sconarscanner start -d:sonar.host.url=https://((sonarqube.host))
+          dotnet sonarscanner begin -k:musicstore -d:sonar.host.url=https://((sonarqube.host)) -d:sonar.login=((sonarqube.token)) 
           dotnet build MusicStore.sln
-          # dotnet sonarscanner end -d:sonar.login=((sonarqube.token))
+          dotnet sonarscanner end -d:sonar.login=((sonarqube.token))
 
 - name: policy-validation
   plan:

--- a/docker/dotnet-sonarscanner/Dockerfile
+++ b/docker/dotnet-sonarscanner/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/sdk:3.1
+
+RUN apt-get update && apt-get install unzip && apt-get clean
+RUN curl -fL --output /tmp/sonarqube.zip https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.0.4.24009/sonar-scanner-msbuild-5.0.4.24009-netcoreapp2.0.zip && \
+    mkdir /tmp/sonarqube && cd /tmp/sonarqube && unzip ../sonarqube.zip && \
+    dotnet tool install dotnet-sonarscanner --version 4.8.0 --tool-path /opt/dotnet/tools && \
+    cd && rm -rf /tmp/sonarqube.zip /tmp/sonarqube
+
+ENV PATH="/opt/dotnet/tools:$PATH"
+

--- a/docker/dotnet-sonarscanner/Dockerfile
+++ b/docker/dotnet-sonarscanner/Dockerfile
@@ -6,5 +6,9 @@ RUN curl -fL --output /tmp/sonarqube.zip https://github.com/SonarSource/sonar-sc
     dotnet tool install dotnet-sonarscanner --version 4.8.0 --tool-path /opt/dotnet/tools && \
     cd && rm -rf /tmp/sonarqube.zip /tmp/sonarqube
 
+RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add - && \
+   echo "deb https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list && \
+   apt-get update && apt-get install adoptopenjdk-11-hotspot -y && apt-get clean
+
 ENV PATH="/opt/dotnet/tools:$PATH"
 


### PR DESCRIPTION
TL;DR
-----

Includes a real static scan in the pipeline

Details
-------

Updates the pipeline to use Sonarqube for a static code scan
instead of faking it out. To do this, I also added an image 
bases on Microsofts .NET Core image that includes the Sonqarqube
plugin for the `dotnet` CLI and the JDK that it needs to run.

Includes a convenience script `build-and-push-scanner-image.sh`
that builds the image and pushes it to the private registry.
