### PR TITLE
Uses a replicated copy of HTTP solver

### DIFF
--- a/bin/patch-cert-manager.sh
+++ b/bin/patch-cert-manager.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+REGISTRY=$(yq r $PARAMS_YAML common.harborDomain)
+WORKLOAD_CLUSTER=$(yq r ${PARAMS_YAML} clusters.workload-cluster)
+
+PREVIOUS_CONTEXT=$(kubectl config current-context)
+
+IMAGE_ARG="--acme-http01-solver-image=${REGISTRY}/cert-manager/cert-manager-acmesolver:canary"
+PATCH=$(jq -n --arg flag "${IMAGE_ARG}" '[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": $flag}]')
+
+kubectl config use-context ${WORKLOAD_CLUSTER}-admin@${WORKLOAD_CLUSTER}
+kubectl patch -n cert-manager deployment cert-manager --type json -p "${PATCH}"
+kubectl config use-context ${PREVIOUS_CONTEXT}

--- a/bin/setup-harbor.sh
+++ b/bin/setup-harbor.sh
@@ -2,12 +2,15 @@
 
 REGISTRY=$(yq r $PARAMS_YAML common.harborDomain)
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/steeltoe.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/cert-manager.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/musicstore.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/sqlserver.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data @harbor/registry/mcr.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data @harbor/registry/hub.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data @harbor/registry/quay.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/sqlserver.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/sqltools.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/eurekaserver.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/hystrix.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/configserver.json
+curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/solver.json

--- a/harbor/project/cert-manager.json
+++ b/harbor/project/cert-manager.json
@@ -1,0 +1,11 @@
+{
+  "project_name": "cert-manager",
+  "metadata": {
+    "auto_scan": "true",
+    "enable_content_trust": "false",
+    "prevent_vul": "true",
+    "public": "true",
+    "reuse_sys_cve_whitelist": "true",
+    "severity": "high"
+  }
+}

--- a/harbor/registry/quay.json
+++ b/harbor/registry/quay.json
@@ -1,0 +1,17 @@
+{
+    "id": 7,
+    "name": "quay-no-auth",
+    "description": "",
+    "type": "quay-io",
+    "url": "https://quay.io",
+    "token_service_url": "",
+    "credential": {
+      "type": "",
+      "access_key": "",
+      "access_secret": ""
+    },
+    "insecure": false,
+    "status": "healthy",
+    "creation_time": "2020-08-14T17:21:11.034238Z",
+    "update_time": "2020-08-14T17:21:11.034241Z"
+  }

--- a/harbor/replication/solver.json
+++ b/harbor/replication/solver.json
@@ -1,0 +1,31 @@
+{
+  "name": "cert-manager-acmesolver",
+  "description": "",
+  "creator": "admin",
+  "src_registry": {
+    "id": 7
+  },
+  "dest_registry": {
+    "id": 0
+  },
+  "dest_namespace": "cert-manager",
+  "filters": [
+      {
+          "type": "name",
+          "value": "jetstack/cert-manager-acmesolver"
+      },
+      {
+          "type": "tag",
+          "value": "canary"
+      }
+  ],
+  "trigger": {
+    "type": "scheduled",
+    "trigger_settings": {
+      "cron": "0 20 10 */1,7,14,28 * *"
+    }
+  },
+  "deletion": false,
+  "override": true,
+  "enabled": true
+}


### PR DESCRIPTION
TL;DR
-----

Configures the workload cluster to use a replicated copy of the
cert manager HTTP solver

Details
-------

I ran into an issue where certificates were not being issued in
my workload cluster because of the image policy. The pod that 
responds to the challenge from Let's Encrypt was unable to run
in namespaces that were restricted to only run workloads from
the private registry.

Two solutions presented themselves, switch to a DNS challenge or
replicating the solver image into our private registry. The DNS
challenge is my usually approach, but there's a simple elegance
to the HTTP solver that I wanted to maintain. I found out that a
command-line flag for the cert manager controller allowed me to 
change the image, so I decided to use that option plus a local
replica of the image to solve the problem.

This change includes the Harbor setup for the replication and 
a script `patch-cert-manager.sh` that patches cert manager on
the workload cluster to use it.
