### PR TITLE
Deploys infrastructure to the correct namespace

### DIFF
--- a/bin/generate-and-apply-infra.sh
+++ b/bin/generate-and-apply-infra.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
-ytt -f k8s/infra.yml -f secrets/lab.yml --ignore-unknown-comments | 
-    kapp deploy -n tanzu-kapp -a steeltoe-services -f - -y
+WORKLOAD_CLUSTER=$(yq r ${PARAMS_YAML} clusters.workload-cluster)
+
+PREVIOUS_CONTEXT=$(kubectl config current-context)
+kubectl config use-context "${WORKLOAD_CLUSTER}-admin@${WORKLOAD_CLUSTER}"
+ytt -f k8s/infra.yml -f secrets/lab.yml --ignore-unknown-comments |
+    kapp deploy -n tanzu-kapp -a steeltoe-services --into-ns musicstore -f - -y
+kubectl config use-context ${PREVIOUS_CONTEXT}
 


### PR DESCRIPTION
TL;DR
-----

Instructs `kapp` to deploy infrastructure to `musicstore` namespace

Details
-------

Fixes an earlier update to use the `tanzu-kapp` namespace for the
`kapp` metadata for the infrastructure services to make sure that
the services are deployed into the `musicstore` namespace where
the music store services and interface expect them to be.
