### PR TITLE
Assures secrets go in the right cluster

### DIFF
--- a/bin/generate-and-apply-secrets.sh
+++ b/bin/generate-and-apply-secrets.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
+SERVICES_CLUSTER=$(yq r ${PARAMS_YAML} clusters.shared-services-cluster)
+
 TEAM=$(yq r ${PARAMS_YAML} common.team)
+PREVIOUS_CONTEXT=$(kubectl config current-context)
+kubectl config use-context "${SERVICES_CLUSTER}-admin@${SERVICES_CLUSTER}"
 ytt -f concourse/secrets -f secrets/lab.yml --ignore-unknown-comments | 
-    kapp deploy -n tanzu-kapp -a ${TEAM}-secrets -f - -y
+    kapp deploy -n tanzu-kapp -a ${TEAM}-secrets --into-ns concourse-${TEAM} -f - -y
+kubectl config use-context ${PREVIOUS_CONTEXT}
 


### PR DESCRIPTION
TL;DR
-----

Changes context to the shared services cluster before applying
the secrets

Details
-------

Updates the script the setup Concourse secrets to make sure it
places them in the correct cluster and namespace. Also restores
the Kubernetes context to whatever it was beforehand.
